### PR TITLE
Add explicit workflow permissions

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     types: [opened, labeled, unlabeled, synchronize]
 
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
 jobs:
   validate-pr-label:
     name: Validate the Pull Request's labels

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "*"
 
+permissions:
+  contents: read
+
 jobs:
   run-checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches-ignore: [main]
 
+permissions:
+  contents: read
+
 jobs:
   run-checks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add explicit workflow token permissions to workflows flagged by code scanning
- grant read-only contents access for test and publish workflows
- grant read-only pull request and issue access for PR label validation

## Testing
- parsed all workflow YAML files locally